### PR TITLE
Updates package.json command to run jshint

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Create a `package.json` file and paste the following:
     "jshint": "^2.6.0"
   },
   "scripts": {
-    "test": "./node_modules/jshint/bin/jshint hello.js"
+    "test": "jshint hello.js"
   }
 }
 ```


### PR DESCRIPTION
	* As per issue #33, node no longer requires the specification of the full path of jshint. Instead of `./node_modules/jshint/bin/jshint app.js`, `jshint app.js` is sufficient to run the linter against your project.